### PR TITLE
add disable_mdns feature

### DIFF
--- a/07_disable_mdns.sh
+++ b/07_disable_mdns.sh
@@ -1,0 +1,4 @@
+export ROLE=worker
+envsubst < /root/99-openshift-disable-mdns.sample.yaml > /root/manifests/99-openshift-worker-disable-mdns.yaml
+export ROLE=master
+envsubst < /root/99-openshift-disable-mdns.sample.yaml > /root/manifests/99-openshift-master-disable-mdns.yaml

--- a/99-openshift-disable-mdns.sample.yaml
+++ b/99-openshift-disable-mdns.sample.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: ${ROLE}
+  name: 99-${ROLE}-disable-mdns
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.1.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+        - contents:
+            source: data:,
+          overwrite: true
+          mode: 420
+          path: /etc/kubernetes/manifests/mdns-publisher.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,6 +19,10 @@ bash /root/03_network.sh
 /root/07_nbde.sh
 {% endif %}
 
+{% if disable_mdns %}
+/root/07_disable_mdns.sh
+{% endif %}
+
 {% if ntp %}
 /root/08_ntp.sh
 {% endif %}

--- a/kcli_default.yml
+++ b/kcli_default.yml
@@ -78,5 +78,6 @@ imagecontentsources: []
 fips: false
 cas: []
 nbde: false
+disable_mdns: false
 ntp: false
 ntp_server: 0.rhel.pool.ntp.org

--- a/kcli_plan.yml
+++ b/kcli_plan.yml
@@ -116,6 +116,7 @@ apps:
  - 05_cache.sh
  - 06_disconnected.sh
  - 07_nbde.sh
+ - 07_disable_mdns.sh
  - 08_ntp.sh
  - 09_deploy_openshift.sh
  - 10_nfs.sh
@@ -140,6 +141,7 @@ apps:
  - 99-openshift-tang-encryption-clevis.sample.yaml
  - 99-openshift-tang-encryption-ka.sample.yaml
  - 99-openshift-chrony.sample.yaml
+ - 99-openshift-disable-mdns.sample.yaml
 {%- if not lab %}
  scripts:
 {%- if build %}


### PR DESCRIPTION
This will disable mdns by nullifying it's static pod definition.
mdns is not strictly needed in envs where all hosts have dns A record.
disabling it will reduce amount of multicasts in the network, which is important in envs with mid-large amount of nodes.

The disable_mdns is false by default, retaining original behavior