### PR TITLE
change git checkout to shallow copy

### DIFF
--- a/tekton/pipeline.yml
+++ b/tekton/pipeline.yml
@@ -54,8 +54,7 @@ spec:
     script: |
      #!/usr/bin/env sh
      cd /source
-     git clone $URL .
-     git checkout $COMMIT
+     git clone ${URL} --branch ${COMMIT} --single-branch --depth=1
     volumeMounts:
     - mountPath: /source
       name: git-source
@@ -80,7 +79,7 @@ spec:
       value: $(params.tag)
     script: |
      #!/usr/bin/env bash
-     cd /source
+     cd /source/
      echo kcli create plan --force $INPUTFILE --paramfile $PARAMFILE -P pullsecret="$PULLSECRET" -P launch_steps="$LAUNCH_STEPS" -P deploy_openshift="$DEPLOY_OPENSHIFT" -P version="$VERSION" -P tag="$TAG" $PLAN
      kcli create plan --force -f $INPUTFILE --paramfile $PARAMFILE -P pullsecret="$PULLSECRET" -P launch_steps="$LAUNCH_STEPS" -P deploy_openshift="$DEPLOY_OPENSHIFT" -P version="$VERSION" -P tag="$TAG" $PLAN
     volumeMounts:


### PR DESCRIPTION
This will checkout a single branch only, without the history
which is faster.

We're only using git to copy all the needed files, as this is used
internally by the pipeline, we are not going to commit or change the
history anyhow.
