### PR TITLE
Fix disconnected pull-secret

### DIFF
--- a/ztp/acm/assisted-service.sample.yml
+++ b/ztp/acm/assisted-service.sample.yml
@@ -18,6 +18,9 @@ data:
 {% if ztp_disable_validations %}
   DISABLED_HOST_VALIDATIONS: belongs-to-majority-group,belongs-to-machine-cidr
 {% endif %}
+{% if disconnected %}
+  PUBLIC_CONTAINER_REGISTRIES: "quay.io,registry.svc.ci.openshift.org,registry.redhat.io"
+{% endif %}
 ---
 apiVersion: agent-install.openshift.io/v1beta1
 kind: AgentServiceConfig

--- a/ztp/acm/assisted-service.sh
+++ b/ztp/acm/assisted-service.sh
@@ -13,9 +13,7 @@ curl -Lk $RHCOS_ROOTFS > /var/www/html/rhcos-live-rootfs.x86_64.img
 {% if acm %}
 tasty install advanced-cluster-management --wait
 oc create -f /root/ztp/acm/cr.yml
-sleep 240
-oc patch hiveconfig hive --type merge -p '{"spec":{"targetNamespace":"hive","logLevel":"debug","featureGates":{"custom":{"enabled":["AlphaAgentInstallStrategy"]},"featureSet":"Custom"}}}'
-sleep 120
+until oc get crd/agentserviceconfigs.agent-install.openshift.io >/dev/null 2>&1 ; do sleep 1 ; done
 {% else %}
 oc create -f /root/ztp/acm/ai_install.yml
 {% endif %}


### PR DESCRIPTION
Also, the hive patch is not required since 2.4.1 https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html-single/clusters/index#enable-cim