### PR TITLE
Workaround for broken nfs-utils

### DIFF
--- a/scripts/10_nfs.sh
+++ b/scripts/10_nfs.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 PRIMARY_NIC=$(ls -1 /sys/class/net | grep 'eth\|en' | head -1)
 export KUBECONFIG=/root/ocp/auth/kubeconfig
 export PRIMARY_IP=$(ip -o addr show $PRIMARY_NIC | head -1 | awk '{print $4}' | cut -d'/' -f1)
-dnf -y install nfs-utils
+# Latest nfs-utils 2.3.3-51 is broken
+rpm -qi nfs-utils || dnf -y install nfs-utils
 test ! -f /usr/lib/systemd/system/firewalld.service || systemctl disable --now firewalld
 systemctl enable --now nfs-server
 export MODE="ReadWriteOnce"


### PR DESCRIPTION
Don't update NFS utils to latest if it present on the disk. Prevent the update to a broken version