### PR TITLE
Use sudo and system connection of virsh when executing commands

### DIFF
--- a/kcli_pre.sh
+++ b/kcli_pre.sh
@@ -143,7 +143,7 @@ POOLPATH=$(kcli -C $CLIENT list pool | grep $POOL | cut -d"|" -f 3 | xargs)
 export LC_ALL="en_US.UTF-8"
 export LIBVIRT_DEFAULT_URI=$(kcli -C $CLIENT info host | grep Connection | sed 's/Connection: //')
 find $POOLPATH/boot-* -type f -mtime +2 -exec sh -c 'virsh -c qemu:///system vol-delete {} || sudo rm {}' \;
-find /var/lib/libvirt/openshift-images/${CLUSTER}-*-bootstrap -exec sh -c 'virsh -c qemu:///system pool-delete {} || rm -rf {}' \;
+find /var/lib/libvirt/openshift-images/${CLUSTER}-*-bootstrap -exec sh -c 'virsh -c qemu:///system pool-delete {} || sudo rm -rf {}' \;
 VMS=$(kcli -C $CLIENT list vm | grep ${CLUSTER}-.*-bootstrap | cut -d"|" -f 2 | xargs)
 [ -z "$VMS" ] || kcli -C $CLIENT delete vm --yes $VMS
 POOLS=$(kcli -C $CLIENT list pool --short | grep $CLUSTER | cut -d"|" -f2 | xargs)

--- a/kcli_pre.sh
+++ b/kcli_pre.sh
@@ -142,8 +142,8 @@ POOL={{ pool }}
 POOLPATH=$(kcli -C $CLIENT list pool | grep $POOL | cut -d"|" -f 3 | xargs)
 export LC_ALL="en_US.UTF-8"
 export LIBVIRT_DEFAULT_URI=$(kcli -C $CLIENT info host | grep Connection | sed 's/Connection: //')
-find $POOLPATH/boot-* -type f -mtime +2 -exec sh -c 'virsh vol-delete {} || sudo rm {}' \;
-find /var/lib/libvirt/openshift-images/${CLUSTER}-*-bootstrap -exec sh -c 'virsh pool-delete {} || rm -rf {}' \;
+find $POOLPATH/boot-* -type f -mtime +2 -exec sh -c 'virsh -c qemu:///system vol-delete {} || sudo rm {}' \;
+find /var/lib/libvirt/openshift-images/${CLUSTER}-*-bootstrap -exec sh -c 'virsh -c qemu:///system pool-delete {} || rm -rf {}' \;
 VMS=$(kcli -C $CLIENT list vm | grep ${CLUSTER}-.*-bootstrap | cut -d"|" -f 2 | xargs)
 [ -z "$VMS" ] || kcli -C $CLIENT delete vm --yes $VMS
 POOLS=$(kcli -C $CLIENT list pool --short | grep $CLUSTER | cut -d"|" -f2 | xargs)


### PR DESCRIPTION
Usually all changes on hosts are done with `-c qemu:///system`, but
by default user runs as user in `qemu:///session`. Specify
explicitly `system` connection when running commands with virsh.