### PR TITLE
Enable resetting the BMC for Dell servers

### DIFF
--- a/plans/kcli_plan_default.yml
+++ b/plans/kcli_plan_default.yml
@@ -54,6 +54,7 @@ provisioning_installer_ip: 172.22.0.253
 provisioning_macs: []
 bmc_user: root
 bmc_password: calvin
+reset_bmc: false
 baremetal_cidr:
 baremetal_macs: []
 baremetal_ips: []

--- a/scripts/09_deploy_openshift.sh
+++ b/scripts/09_deploy_openshift.sh
@@ -11,6 +11,14 @@ bash /root/bin/clean.sh || true
 mkdir -p ocp/openshift
 python3 /root/bin/ipmi.py off
 python3 /root/bin/redfish.py off
+{% if reset_bmc %}
+  {% for worker in workers %}
+  {% if worker['model']|default('kvm') == "dell" %}
+      worker_ip={% worker["redfish_address"] %}
+      curl -i -k -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -u {{ bmc_user }}:{{ bmc_password }} --data '{"ResetType":"GracefulRestart"}' 'https://"${worker_ip}"/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Manager.Reset'
+    {% endif %}
+  {% endfor %}
+{% endif %}
 cp install-config.yaml ocp
 openshift-baremetal-install --dir ocp --log-level debug create manifests
 {% if localhost_fix %}


### PR DESCRIPTION
We've encountered a bug during several baremetal OCP
deployments involving Dell servers due to "stuck" virtual media,
which can be solved by rebooting the IDRAC.