### PR TITLE
Fix wait for workers

### DIFF
--- a/scripts/09_deploy_openshift.sh
+++ b/scripts/09_deploy_openshift.sh
@@ -59,7 +59,9 @@ CURRENT_WORKERS=$(oc get nodes --selector='node-role.kubernetes.io/worker' | gre
     echo "Timeout waiting for Current workers number $CURRENT_WORKERS to match expected worker number $TOTAL_WORKERS"
     break
   fi
-  CURRENT_WORKERS=$(oc get nodes --selector='node-role.kubernetes.io/worker' | grep -c " Ready")
+  # We need to remove masters from the command below, otherwise if there are schedulable masters enabled (via extra manifest)
+  # the script loops forever
+  CURRENT_WORKERS=$(oc get nodes --selector='node-role.kubernetes.io/worker' | grep -v master | grep -c " Ready")
   echo "Waiting for all workers to show up..."
   sleep 5
   TIMEOUT=$(($TIMEOUT + 5))


### PR DESCRIPTION
When creating a cluster with masters and workers where you make masters schedulable using an installation extra manifest, the openshift install script will not expect this and will keep looping until the timeout happens. This fixes that by removing masters from the oc get nodes output.