### PR TITLE
Added support for multiple icsps in the same file

### DIFF
--- a/ztp/acm/gen_registries.py
+++ b/ztp/acm/gen_registries.py
@@ -6,18 +6,17 @@ import yaml
 manifestfile = glob.glob('/root/manifests-redhat-operator-index-*/imageContentSourcePolicy.yaml')[0]
 results = ''
 with open(manifestfile) as f:
-    data = yaml.safe_load(f)
-
-mirrors = data['spec']['repositoryDigestMirrors']
-for mirror in mirrors:
-    registry1 = mirror['source']
-    registry2 = mirror['mirrors'][0]
-    results += """\n    [[registry]]
+    data = yaml.safe_load_all(f)
+    for d in data:
+        mirrors = d['spec']['repositoryDigestMirrors']
+        for mirror in mirrors:
+            registry1 = mirror['source']
+            registry2 = mirror['mirrors'][0]
+            results += """\n    [[registry]]
     prefix = ""
     location = "{registry1}"
     mirror-by-digest-only = true
 
     [[registry.mirror]]
       location = "{registry2}"\n""".format(registry1=registry1, registry2=registry2)
-
 print(results)


### PR DESCRIPTION
The current implementation of gen_registries.py will fail if the ICSP YAML file contains more than one ICSP (separated with ---). oc adm mirror outputs everything in the same ICSP, but oc-mirror creates multiple ICSPs in the same YAML file. This patch does gen_registries.py work with either output.

Signed-off-by: Mario Vazquez <mavazque@redhat.com>