### PR TITLE
Make sure manifests folder always exists

### DIFF
--- a/scripts/06_disconnected_mirror.sh
+++ b/scripts/06_disconnected_mirror.sh
@@ -82,6 +82,8 @@ DISCONNECTED_PULLSECRET=$(cat /root/disconnected_pull.json | tr -d [:space:])
 echo -e "pullSecret: |\n  $DISCONNECTED_PULLSECRET" >> /root/install-config.yaml
 fi
 
+# We need to make sure manifests folder exists, if the plan points to a non-existing manifest folder in the node running the plan this folder won't exist and the script will fail
+mkdir -p /root/manifests
 cp /root/machineconfigs/99-operatorhub.yaml /root/manifests
 
 {% for image in disconnected_extra_images %}

--- a/scripts/06_disconnected_olm.sh
+++ b/scripts/06_disconnected_olm.sh
@@ -60,5 +60,8 @@ if [ $(grep -c "No new images detected" /tmp/mirror-registry-output) -eq 1 ] ; t
   python3 /root/bin/mapping_to_icsp.py -m /root/oc-mirror-workspace/mapping.txt -o /root/oc-mirror-workspace/results-mapping/ -c /root/mirror-config.yaml
 fi
 
+# We need to make sure manifests folder exists, if the plan points to a non-existing manifest folder in the node running the plan this folder won't exist and the script will fail
+mkdir -p /root/manifests
+
 oc apply -f /root/oc-mirror-workspace/results-*/*imageContentSourcePolicy.yaml 2>/dev/null || cp /root/oc-mirror-workspace/results-*/*imageContentSourcePolicy.yaml /root/manifests
 oc apply -f /root/oc-mirror-workspace/results-*/*catalogSource* 2>/dev/null || cp /root/oc-mirror-workspace/results-*/*catalogSource* /root/manifests

--- a/scripts/07_nbde.sh
+++ b/scripts/07_nbde.sh
@@ -19,6 +19,10 @@ systemctl start tangd.socket
 export IP=$(ip -o addr show $PRIMARY_NIC | head -1 | awk '{print $4}' | cut -d'/' -f1)
 export TANG_URL=http://"$IP:7500"
 export THP="$(tang-show-keys 7500)"
+
+# We need to make sure manifests folder exists, if the plan points to a non-existing manifest folder in the node running the plan this folder won't exist and the script will fail
+mkdir -p /root/manifests
+
 export ROLE=worker
 envsubst < /root/machineconfigs/99-openshift-tang-encryption-clevis.sample.yaml > /root/manifests/99-openshift-worker-tang-encryption-clevis.yaml
 envsubst < /root/machineconfigs/99-openshift-tang-encryption-ka.sample.yaml > /root/manifests/99-openshift-worker-tang-encryption-ka.yaml

--- a/scripts/08_ntp.sh
+++ b/scripts/08_ntp.sh
@@ -10,6 +10,10 @@ export NTP_DATA=$((cat << EOF
     logdir /var/log/chrony
 EOF
 ) | base64 -w0)
+
+# We need to make sure manifests folder exists, if the plan points to a non-existing manifest folder in the node running the plan this folder won't exist and the script will fail
+mkdir -p /root/manifests
+
 export ROLE=worker
 envsubst < /root/machineconfigs/99-openshift-chrony.sample.yaml > /root/manifests/99-openshift-worker-chrony.yaml
 export ROLE=master

--- a/scripts/09_deploy_openshift.sh
+++ b/scripts/09_deploy_openshift.sh
@@ -9,6 +9,8 @@ export KUBECONFIG=/root/ocp/auth/kubeconfig
 export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$(cat /root/version.txt)
 bash /root/bin/clean.sh || true
 mkdir -p ocp/openshift
+# We need to make sure manifests folder exists, if the plan points to a non-existing manifest folder in the node running the plan this folder won't exist and the script will fail
+mkdir -p /root/manifests
 python3 /root/bin/ipmi.py off
 python3 /root/bin/redfish.py off
 {% if bmc_reset %}


### PR DESCRIPTION
If the plan points to a manifests folder that doesn't exist some scripts will fail since the folder won't be copied by the plan.

This PR modifies the scripts relying on the manifests folder so if the folder doesn't exist, it will be created by the scripts.