### PR TITLE
Support filtering OLM catalogs with oc-mirror

### DIFF
--- a/scripts/mirror-config.yaml.sample
+++ b/scripts/mirror-config.yaml.sample
@@ -15,28 +15,92 @@ mirror:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v${OCP_RELEASE}
     packages:
 {% for package in disconnected_operators %}
+{% if package.name is defined %} {# Comment: Support new syntax allowing to further filtering #}
+    - name: {{ package.name }}
+{% else %} {# Comment: Support old syntax #}
     - name: {{ package }}
+{% endif %}
+{% if package.channels is defined and package.channels|length > 0 %}
+      channels:
+{% for channel in package.channels %}
+      - name: {{ channel.name }}
+{% if channel.minVersion is defined %}
+        minVersion: {{ channel.minVersion }}
+{% endif %}
+{% if channel.maxVersion is defined %}
+        maxVersion: {{ channel.maxVersion }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if disconnected_certified_operators %}
   - catalog: registry.redhat.io/redhat/certified-operator-index:v${OCP_RELEASE}
     packages:
 {% for package in disconnected_certified_operators %}
+{% if package.name is defined %}
+    - name: {{ package.name }}
+{% else %}
     - name: {{ package }}
+{% endif %}
+{% if package.channels is defined and package.channels|length > 0 %}
+      channels:
+{% for channel in package.channels %}
+      - name: {{ channel.name }}
+{% if channel.minVersion is defined %}
+        minVersion: {{ channel.minVersion }}
+{% endif %}
+{% if channel.maxVersion is defined %}
+        maxVersion: {{ channel.maxVersion }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if disconnected_community_operators %}
   - catalog: registry.redhat.io/redhat/community-operator-index:v${OCP_RELEASE}
     packages:
 {% for package in disconnected_community_operators %}
+{% if package.name is defined %}
+    - name: {{ package.name }}
+{% else %}
     - name: {{ package }}
+{% endif %}
+{% if package.channels is defined and package.channels|length > 0 %}
+      channels:
+{% for channel in package.channels %}
+      - name: {{ channel.name }}
+{% if channel.minVersion is defined %}
+        minVersion: {{ channel.minVersion }}
+{% endif %}
+{% if channel.maxVersion is defined %}
+        maxVersion: {{ channel.maxVersion }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if disconnected_marketplace_operators %}
   - catalog: registry.redhat.io/redhat/redhat-marketplace-index:v${OCP_RELEASE}
     packages:
 {% for package in disconnected_marketplace_operators %}
+{% if package.name is defined %}
+    - name: {{ package.name }}
+{% else %}
     - name: {{ package }}
+{% endif %}
+{% if package.channels is defined and package.channels|length > 0 %}
+      channels:
+{% for channel in package.channels %}
+      - name: {{ channel.name }}
+{% if channel.minVersion is defined %}
+        minVersion: {{ channel.minVersion }}
+{% endif %}
+{% if channel.maxVersion is defined %}
+        maxVersion: {{ channel.maxVersion }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if disconnected_extra_catalogs %}


### PR DESCRIPTION
This adds support for filtering the OLM catalogs. Examples below:

**disconnected_operators**

It supports a new syntax where you can provide a dictionary for filtering the catalog for a given operator. It also supports old syntax where the name was not used. For example, the input below:

~~~yaml
disconnected_operators:
- name: advanced-cluster-management
  channels:
  - name: stable
    minVersion: '1.0'
    maxVersion: '1.1'
- name: openshift-gitops-operator
- name: multicluster-engine
  channels:
  - name: latest
- name: lvms-operator
  channels:
  - name: testing
    minVersion: '1.0'
- topology-aware-lifecycle-manager
- local-storage-operator
~~~

Will produce this:

~~~yaml
  - catalog: registry.redhat.io/redhat/redhat-operator-index:v${OCP_RELEASE}
    packages:
     - name: advanced-cluster-management
      channels:
      - name: stable
        minVersion: 1.0
        maxVersion: 1.1
     - name: openshift-gitops-operator
     - name: multicluster-engine
      channels:
      - name: latest
     - name: lvms-operator
      channels:
      - name: testing
        minVersion: 1.0
     - name: topology-aware-lifecycle-manager
     - name: local-storage-operator
~~~
