### PR TITLE
Exclude podman interface from primary nic search

### DIFF
--- a/machineconfigs/99-localhost-fix-ctlplane.yaml
+++ b/machineconfigs/99-localhost-fix-ctlplane.yaml
@@ -21,7 +21,7 @@ spec:
           [Service]
           Type=oneshot
           ExecStart=/bin/bash -c "if [[ $(hostname) == *localhost* ]]; then \
-             PRIMARY_NIC=$(ls -1 /sys/class/net | head -1) ;\
+             PRIMARY_NIC=$(ls -1 /sys/class/net | grep -v podman | head -1) ;\
              HOSTNAME=$(ip a l $PRIMARY_NIC | grep link | awk '{print $2}' | sed 's/:/-/g') ;\
              echo $HOSTNAME > /etc/hostname ;\
              nmcli general hostname $HOSTNAME ;\

--- a/machineconfigs/99-localhost-fix-worker.yaml
+++ b/machineconfigs/99-localhost-fix-worker.yaml
@@ -21,7 +21,7 @@ spec:
           [Service]
           Type=oneshot
           ExecStart=/bin/bash -c "if [[ $(hostname) == *localhost* ]]; then \
-             PRIMARY_NIC=$(ls -1 /sys/class/net | head -1) ;\
+             PRIMARY_NIC=$(ls -1 /sys/class/net | grep -v podman | head -1) ;\
              HOSTNAME=$(ip a l $PRIMARY_NIC | grep link | awk '{print $2}' | sed 's/:/-/g') ;\
              echo $HOSTNAME > /etc/hostname ;\
              nmcli general hostname $HOSTNAME ;\

--- a/scripts/00_virtual.sh
+++ b/scripts/00_virtual.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PRIMARY_NIC=$(ls -1 /sys/class/net | head -1)
+PRIMARY_NIC=$(ls -1 /sys/class/net | grep -v podman | head -1)
 {% if not 'rhel' in image %}
 dnf clean all
 sleep 30

--- a/scripts/03_cache.sh
+++ b/scripts/03_cache.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PRIMARY_NIC=$(ls -1 /sys/class/net | head -1)
+PRIMARY_NIC=$(ls -1 /sys/class/net | grep -v podman | head -1)
 export PATH=/root/bin:$PATH
 dnf -y install httpd
 dnf -y update libgcrypt

--- a/scripts/04_disconnected_quay.sh
+++ b/scripts/04_disconnected_quay.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 export HOME=/root
 export USER=root
-PRIMARY_NIC=$(ls -1 /sys/class/net | head -1)
+PRIMARY_NIC=$(ls -1 /sys/class/net | grep -v podman | head -1)
 export PATH=/root/bin:$PATH
 export PULL_SECRET="/root/openshift_pull.json"
 dnf -y install podman httpd jq libseccomp-devel

--- a/scripts/04_disconnected_registry.sh
+++ b/scripts/04_disconnected_registry.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PRIMARY_NIC=$(ls -1 /sys/class/net | head -1)
+PRIMARY_NIC=$(ls -1 /sys/class/net | grep -v podman | head -1)
 export PATH=/root/bin:$PATH
 export PULL_SECRET="/root/openshift_pull.json"
 dnf -y install podman httpd httpd-tools jq skopeo libseccomp-devel

--- a/scripts/05_nbde.sh
+++ b/scripts/05_nbde.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PRIMARY_NIC=$(ls -1 /sys/class/net | head -1)
+PRIMARY_NIC=$(ls -1 /sys/class/net | grep -v podman | head -1)
 yum -y install clevis tang
 semanage port -a -t tangd_port_t -p tcp 7500
 # firewall-cmd --add-port=7500/tcp


### PR DESCRIPTION
When searching for primary nic and podman is running in this time there is network interface cni-podman0 created and it's choosen as a primary nic. Which is wrong, so exclude it specifically.